### PR TITLE
Improve parsing of network responses and app messages

### DIFF
--- a/Sources/Models/AppMessage.swift
+++ b/Sources/Models/AppMessage.swift
@@ -1,24 +1,18 @@
 //
 //  AppMessage.swift
-//
+//  
 //
 //  Created by Brent Whitman on 2024-01-15.
 //
 
 import Foundation
 
-public struct AppMessage: Codable {
-    public enum MessageType: String, Codable {
+struct AppMessage: Codable {
+    enum MessageType: String, Codable {
+        case hang
+        case functionCall = "function-call"
         case transcript
     }
     
-    public enum TranscriptType: String, Codable {
-        case final
-        case partial
-    }
-    
-    public let type: MessageType
-    public let role: String?
-    public let transcriptType: TranscriptType?
-    public let transcript: String?
+    let type: MessageType
 }

--- a/Sources/Models/AppMessage.swift
+++ b/Sources/Models/AppMessage.swift
@@ -1,0 +1,24 @@
+//
+//  AppMessage.swift
+//
+//
+//  Created by Brent Whitman on 2024-01-15.
+//
+
+import Foundation
+
+public struct AppMessage: Codable {
+    public enum MessageType: String, Codable {
+        case transcript
+    }
+    
+    public enum TranscriptType: String, Codable {
+        case final
+        case partial
+    }
+    
+    public let type: MessageType
+    public let role: String?
+    public let transcriptType: TranscriptType?
+    public let transcript: String?
+}

--- a/Sources/Models/FunctionCall.swift
+++ b/Sources/Models/FunctionCall.swift
@@ -1,0 +1,18 @@
+//
+//  FunctionCall.swift
+//
+//
+//  Created by Brent Whitman on 2024-01-15.
+//
+
+import Foundation
+
+public struct FunctionCall {
+    enum CodingKeys: CodingKey {
+        case name
+        case parameters
+    }
+    
+    public let name: String
+    public let parameters: [String: Any]
+}

--- a/Sources/Models/Transcript.swift
+++ b/Sources/Models/Transcript.swift
@@ -1,0 +1,24 @@
+//
+//  Transcript.swift
+//
+//
+//  Created by Brent Whitman on 2024-01-15.
+//
+
+import Foundation
+
+public struct Transcript: Codable {
+    public enum TranscriptType: String, Codable {
+        case final
+        case partial
+    }
+    
+    public enum Role: String, Codable {
+        case assistant
+        case user
+    }
+    
+    public let role: Role
+    public let transcriptType: TranscriptType
+    public let transcript: String
+}

--- a/Sources/Models/VapiError.swift
+++ b/Sources/Models/VapiError.swift
@@ -12,4 +12,5 @@ public enum VapiError: Swift.Error {
     case customError(String)
     case existingCallInProgress
     case noCallInProgress
+    case decodingError(underlying: Error, response: String?)
 }

--- a/Sources/Models/VapiError.swift
+++ b/Sources/Models/VapiError.swift
@@ -12,5 +12,5 @@ public enum VapiError: Swift.Error {
     case customError(String)
     case existingCallInProgress
     case noCallInProgress
-    case decodingError(underlying: Error, response: String?)
+    case decodingError(message: String, response: String? = nil)
 }

--- a/Sources/NetworkManager.swift
+++ b/Sources/NetworkManager.swift
@@ -10,7 +10,12 @@ class NetworkManager {
     
     func perform<T: Decodable>(request: URLRequest) async throws -> T {
         let (data, _) = try await session.data(for: request)
-        let result = try JSONDecoder().decode(T.self, from: data)
-        return result
+        do {
+            let result = try JSONDecoder().decode(T.self, from: data)
+            return result
+        } catch {
+            let responseString = String(data: data, encoding: .utf8)
+            throw VapiError.decodingError(underlying: error, response: responseString)
+        }
     }
 }

--- a/Sources/NetworkManager.swift
+++ b/Sources/NetworkManager.swift
@@ -15,7 +15,7 @@ class NetworkManager {
             return result
         } catch {
             let responseString = String(data: data, encoding: .utf8)
-            throw VapiError.decodingError(underlying: error, response: responseString)
+            throw VapiError.decodingError(message: error.localizedDescription, response: responseString)
         }
     }
 }


### PR DESCRIPTION
- Include the response body as a property of decoding errors to aid in troubleshooting
- Unescape app messages so that they can be decoded
- Create a struct for app messages and decode them to this struct before publishing them so that clients don't need to do the decoding on their end