### PR TITLE
Make call id public

### DIFF
--- a/Sources/Models/WebCallResponse.swift
+++ b/Sources/Models/WebCallResponse.swift
@@ -9,5 +9,5 @@ import Foundation
 
 public struct WebCallResponse: Decodable {
     let webCallUrl: URL
-    let id: String
+    public let id: String
 }


### PR DESCRIPTION
Before, selecting the id off of the response would throw an error ( 'id' is inaccessible due to 'internal' protection level). With this change, it correctly makes the id accessible.
``` swift
let response = try await vapi.start(assistant: assistant)
print("id: \(response.id)") // abb4...
```

This is useful to be able to write logic to attribute a call to a user session