### PR TITLE
Add remote audio level listener to get the volume levels of the speaker

### DIFF
--- a/Sources/Vapi.swift
+++ b/Sources/Vapi.swift
@@ -73,6 +73,10 @@ public final class Vapi: CallClientDelegate {
         call?.localAudioLevel
     }
     
+    @MainActor public var remoteAudioLevel: Float? {
+        call?.remoteParticipantsAudioLevel.values.first
+    }
+    
     // MARK: - Init
     
     public init(configuration: Configuration) {
@@ -279,6 +283,14 @@ public final class Vapi: CallClientDelegate {
     public func startLocalAudioLevelObserver() async throws {
         do {
             try await call?.startLocalAudioLevelObserver()
+        } catch {
+            throw error
+        }
+    }
+    
+    public func startRemoteParticipantsAudioLevelObserver() async throws {
+        do {
+            try await call?.startRemoteParticipantsAudioLevelObserver()
         } catch {
             throw error
         }


### PR DESCRIPTION
Start the remote audio level observer with `try await vapi?.startRemoteParticipantsAudioLevelObserver()`. Then `vapi?.remoteAudioLevel` will have the assistant audio level.  

I named it remoteAudioLevel to fit the Daily naming convension, but we can also call it assistantAudioLevel if that's more clear for vapi. Let me know