### PR TITLE
🐛 Fix Table and Add Required Usage Descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ and add `"Vapi"` to your application/library target, `dependencies`, e.g. like t
 You will need to update your project's Info.plist to add three new entries with the following keys:
 
 - NSMicrophoneUsageDescription
-- NSCameraUsageDescription (optional)
+- NSCameraUsageDescription
 - UIBackgroundModes
 
-For the first two key's values, provide user-facing strings explaining why your app is asking for microphone access.
+For the first two key's values, provide user-facing strings explaining why your app is asking for microphone and camera access.
 
 UIBackgroundModes is handled slightly differently and will resolve to an array. For its first item, specify the value voip. This ensures that audio will continue uninterrupted when your app is sent to the background.
 
-To add the new entries through Xcode, open the Info.plist and add the following four entries (Camera is optional):
+To add the new entries through Xcode, open the Info.plist and add the following four entries:
 
 | Key                                    | Type   | Value                                           |
 |----------------------------------------|--------|-------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ UIBackgroundModes is handled slightly differently and will resolve to an array. 
 
 To add the new entries through Xcode, open the Info.plist and add the following four entries (Camera is optional):
 
-| Key                                  | Type   | Value                                        |
-|--------------------------------------|--------|----------------------------------------------|
-| Privacy - Camera Usage Description|    String    "Your app name needs camera access to work
-| Privacy - Microphone Usage Description| String | "Your app name needs microphone access to work" |
-| Required background modes            | Array  | 1 item                                       |
-| ---> Item 0                          | String | "App provides Voice over IP services"        |
+| Key                                    | Type   | Value                                           |
+|----------------------------------------|--------|-------------------------------------------------|
+| Privacy - Camera Usage Description     | String | "Your app name needs camera access to work"     |
+| Privacy - Microphone Usage Description | String | "Your app name needs microphone access to work" |
+| Required background modes              | Array  | 1 item                                          |
+| ---> Item 0                            | String | "App provides Voice over IP services"           |
 
 If you view the raw file contents of Info.plist, it should look like this:
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ and add `"Vapi"` to your application/library target, `dependencies`, e.g. like t
 You will need to update your project's Info.plist to add three new entries with the following keys:
 
 - NSMicrophoneUsageDescription
+- NSCameraUsageDescription (optional)
 - UIBackgroundModes
 
 For the first two key's values, provide user-facing strings explaining why your app is asking for microphone access.


### PR DESCRIPTION
Table Before:
<img width="863" alt="Screenshot 2025-07-07 at 12 06 41 AM" src="https://github.com/user-attachments/assets/3d170af8-5443-4f4d-8745-539ca20def45" />

I got an error archiving without the camera usage descriptor:
"Missing purpose string in Info.plist. Your app’s code references one or more APIs that access sensitive user data, or the app has one or more entitlements that permit such access. The Info.plist file for the “App.app” bundle should contain a NSCameraUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. If you’re using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. For details, visit: https://developer.apple.com/documentation/uikit/protecting_the_user_s_privacy/requesting_access_to_protected_resources."

`NSCameraUsageDescription` seems to be required (iOS 18.5 and Xcode 16.4).
