### PR TITLE
🐛 Fix Vapi's Latest Tool-Calling

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/daily-co/daily-client-ios",
       "state" : {
-        "revision" : "1b84803a17766240007f11c553ca7debbfcef33b",
-        "version" : "0.22.0"
+        "revision" : "431938db25e5807120e89e2dc5bab1c076729f59",
+        "version" : "0.31.0"
       }
     }
   ],

--- a/Sources/Models/AnyCodable.swift
+++ b/Sources/Models/AnyCodable.swift
@@ -1,0 +1,80 @@
+//
+//  AnyCodable.swift
+//
+//
+//  Created by Anton Begehr on 2025-07-10.
+//
+
+import Foundation
+
+public enum AnyCodable: Codable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case array([AnyCodable])
+    case dictionary([String: AnyCodable])
+    case null
+
+    public init(_ value: Any?) {
+        switch value {
+        case let string as String:
+            self = .string(string)
+        case let int as Int:
+            self = .int(int)
+        case let double as Double:
+            self = .double(double)
+        case let bool as Bool:
+            self = .bool(bool)
+        case let array as [Any]:
+            self = .array(array.map { AnyCodable($0) })
+        case let dict as [String: Any]:
+            self = .dictionary(dict.mapValues { AnyCodable($0) })
+        case nil:
+            self = .null
+        default:
+            self = .null // Fallback for unsupported types
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let int = try? container.decode(Int.self) {
+            self = .int(int)
+        } else if let double = try? container.decode(Double.self) {
+            self = .double(double)
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let array = try? container.decode([AnyCodable].self) {
+            self = .array(array)
+        } else if let dict = try? container.decode([String: AnyCodable].self) {
+            self = .dictionary(dict)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON type")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .dictionary(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}

--- a/Sources/Models/AppMessage.swift
+++ b/Sources/Models/AppMessage.swift
@@ -11,6 +11,7 @@ struct AppMessage: Codable {
     enum MessageType: String, Codable {
         case hang
         case functionCall = "function-call"
+        case toolCalls = "tool-calls"
         case transcript
         case speechUpdate = "speech-update"
         case metadata

--- a/Sources/Models/ConversationUpdate.swift
+++ b/Sources/Models/ConversationUpdate.swift
@@ -5,10 +5,14 @@ public struct Message: Codable {
         case user = "user"
         case assistant = "assistant"
         case system = "system"
+        case tool = "tool"
     }
     
     public let role: Role
-    public let content: String
+    public let content: String? // For role=tool, has the response of the tool call. For role=assistant with tool_calls is nil.
+    public let tool_calls: [ToolCall]? // Only for role=assistant with tool calls.
+    public let tool_call_id: String? // Only for role=tool, with tool response.
+
 }
 
 public struct ConversationUpdate: Codable {

--- a/Sources/Models/ConversationUpdate.swift
+++ b/Sources/Models/ConversationUpdate.swift
@@ -7,11 +7,18 @@ public struct Message: Codable {
         case system = "system"
         case tool = "tool"
     }
-    
+
+    enum CodingKeys: String, CodingKey {
+        case role
+        case content
+        case toolCalls = "tool_calls"
+        case toolCallId = "tool_call_id"
+    }
+
     public let role: Role
     public let content: String? // For role=tool, has the response of the tool call. For role=assistant with tool_calls is nil.
-    public let tool_calls: [ToolCall]? // Only for role=assistant with tool calls.
-    public let tool_call_id: String? // Only for role=tool, with tool response.
+    public let toolCalls: [ToolCall]? // Only for role=assistant with tool calls.
+    public let toolCallId: String? // Only for role=tool, with tool response.
 
 }
 

--- a/Sources/Models/ToolCall.swift
+++ b/Sources/Models/ToolCall.swift
@@ -27,6 +27,6 @@ public extension ToolCall {
         }
 
         public let name: String
-        public let arguments: String // TODO: actually is [String: Any]
+        public let arguments: [String: AnyCodable]
     }
 }

--- a/Sources/Models/ToolCall.swift
+++ b/Sources/Models/ToolCall.swift
@@ -1,0 +1,32 @@
+//
+//  ToolCall.swift
+//
+//
+//  Created by Anton Begehr on 2025-07-10.
+//
+
+import Foundation
+
+public struct ToolCall: Codable {
+    enum CodingKeys: CodingKey {
+        case id
+        case type
+        case function
+    }
+    
+    public let id: String
+    public let type: String
+    public let function: Function
+}
+
+public extension ToolCall {
+    struct Function: Codable {
+        enum CodingKeys: CodingKey {
+            case name
+            case arguments
+        }
+
+        public let name: String
+        public let arguments: String // TODO: actually is [String: Any]
+    }
+}

--- a/Sources/Models/ToolCalls.swift
+++ b/Sources/Models/ToolCalls.swift
@@ -1,11 +1,15 @@
 //
-//  ToolCall.swift
+//  ToolCalls.swift
 //
 //
 //  Created by Anton Begehr on 2025-07-10.
 //
 
 import Foundation
+
+public struct ToolCalls: Codable {
+    public let toolCalls: [ToolCall]
+}
 
 public struct ToolCall: Codable {
     enum CodingKeys: CodingKey {

--- a/Sources/Models/ToolCalls.swift
+++ b/Sources/Models/ToolCalls.swift
@@ -31,6 +31,6 @@ public extension ToolCall {
         }
 
         public let name: String
-        public let arguments: [String: AnyCodable]
+        public let arguments: AnyCodable // In `conversation-update.messages`, this will be an encoded string. In `tool-calls.toolCalls`, this will be a dictionary.
     }
 }

--- a/Sources/Models/ToolCalls.swift
+++ b/Sources/Models/ToolCalls.swift
@@ -31,6 +31,6 @@ public extension ToolCall {
         }
 
         public let name: String
-        public let arguments: AnyCodable // In `conversation-update.messages`, this will be an encoded string. In `tool-calls.toolCalls`, this will be a dictionary.
+        public let arguments: AnyCodable // In `conversation-update`, this will be an encoded string. In `tool-calls`, this will be a dictionary.
     }
 }

--- a/Sources/Models/VapiError.swift
+++ b/Sources/Models/VapiError.swift
@@ -28,7 +28,7 @@ extension VapiError {
         case .noCallInProgress:
             return "No call in progress"
         case .decodingError(let message, let response):
-            return "\(message)\n\(response ?? "No response data")"
+            return "\(message), \(response ?? "no response")"
         case .invalidJsonData:
             return "Invalid JSON data"
         }

--- a/Sources/Models/VapiError.swift
+++ b/Sources/Models/VapiError.swift
@@ -7,11 +7,30 @@
 
 import Foundation
 
-public enum VapiError: Swift.Error {
+public enum VapiError: LocalizedError {
     case invalidURL
     case customError(String)
     case existingCallInProgress
     case noCallInProgress
     case decodingError(message: String, response: String? = nil)
     case invalidJsonData
+}
+
+extension VapiError {
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "URL is invalid"
+        case .customError(let message):
+            return message
+        case .existingCallInProgress:
+            return "An existing call is in progress"
+        case .noCallInProgress:
+            return "No call in progress"
+        case .decodingError(let message, let response):
+            return "\(message)\n\(response ?? "No response data")"
+        case .invalidJsonData:
+            return "Invalid JSON data"
+        }
+    }
 }

--- a/Sources/Vapi.swift
+++ b/Sources/Vapi.swift
@@ -467,31 +467,8 @@ public final class Vapi: CallClientDelegate {
                 let functionCall = FunctionCall(name: name, parameters: parameters)
                 event = Event.functionCall(functionCall)
             case .toolCalls:
-                guard let messageDictionary = try JSONSerialization.jsonObject(with: unescapedData, options: []) as? [String: Any] else {
-                    throw VapiError.decodingError(message: "App message isn't a valid JSON object")
-                }
-                guard let toolsCallsArray = messageDictionary["toolCalls"] as? [[String: Any]] else {
-                    throw VapiError.decodingError(message: "App message missing toolCalls")
-                }
-                let toolCalls: [ToolCall] = try toolsCallsArray.map { dict in
-                    guard let id = dict[ToolCall.CodingKeys.id.stringValue] as? String else {
-                        throw VapiError.decodingError(message: "ToolCall missing id")
-                    }
-                    guard let type = dict[ToolCall.CodingKeys.type.stringValue] as? String else {
-                        throw VapiError.decodingError(message: "ToolCall missing type")
-                    }
-                    guard let functionDict = dict[ToolCall.CodingKeys.function.stringValue] as? [String: Any] else {
-                        throw VapiError.decodingError(message: "ToolCall missing function")
-                    }
-                    guard let name = functionDict[ToolCall.Function.CodingKeys.name.stringValue] as? String else {
-                        throw VapiError.decodingError(message: "ToolCall missing function name")
-                    }
-                    guard let arguments = functionDict[ToolCall.Function.CodingKeys.arguments.stringValue] as? String else {
-                        throw VapiError.decodingError(message: "ToolCall missing function arguments")
-                    }
-                    return .init(id: id, type: type, function: .init(name: name, arguments: arguments))
-                }
-                event = Event.toolCalls(toolCalls)
+                let toolCalls = try decoder.decode(ToolCalls.self, from: unescapedData)
+                event = Event.toolCalls(toolCalls.toolCalls)
             case .hang:
                 event = Event.hang
             case .transcript:

--- a/Sources/Vapi.swift
+++ b/Sources/Vapi.swift
@@ -477,10 +477,10 @@ public final class Vapi: CallClientDelegate {
                     guard let id = dict[ToolCall.CodingKeys.id.stringValue] as? String else {
                         throw VapiError.decodingError(message: "ToolCall missing id")
                     }
-                    guard let type = dict[ToolCall.CodingKeys.id.stringValue] as? String else {
+                    guard let type = dict[ToolCall.CodingKeys.type.stringValue] as? String else {
                         throw VapiError.decodingError(message: "ToolCall missing type")
                     }
-                    guard let functionDict = dict[ToolCall.CodingKeys.id.stringValue] as? [String: Any] else {
+                    guard let functionDict = dict[ToolCall.CodingKeys.function.stringValue] as? [String: Any] else {
                         throw VapiError.decodingError(message: "ToolCall missing function")
                     }
                     guard let name = functionDict[ToolCall.Function.CodingKeys.name.stringValue] as? String else {


### PR DESCRIPTION
Before:

<img width="2474" height="468" alt="Screenshot 2025-07-10 at 4 36 20 PM" src="https://github.com/user-attachments/assets/8721c26b-f356-45e4-81d3-90250872c0ac" />

After:

<img width="1978" height="134" alt="Screenshot 2025-07-10 at 7 18 49 PM" src="https://github.com/user-attachments/assets/ada821fa-1bd1-4695-9592-7714baefeea8" />

I've noticed that on the `tool-calls`-event, the arguments are a json object, whereas on the `conversation-update`-event the `arguments` is an encoded string of the json object, therefore I'm using `AnyCodable` for `function.arguments` to support all json structure and also a basic encoded string. 