### PR TITLE
Sdk error reporting

### DIFF
--- a/Sources/Models/VapiError.swift
+++ b/Sources/Models/VapiError.swift
@@ -9,9 +9,106 @@ import Foundation
 
 public enum VapiError: Swift.Error {
     case invalidURL
+    case urlConstructionFailed(host: String, path: String)
+    case requestBodyEncodingFailed(underlying: Error)
+    case networkFailure(underlying: Error)
+    case webRTCFailure(operation: String, underlying: Error)
     case customError(String)
     case existingCallInProgress
     case noCallInProgress
     case decodingError(message: String, response: String? = nil)
+    case decodingFailure(message: String, response: String? = nil, underlying: Error)
     case invalidJsonData
+}
+
+extension VapiError {
+    public enum Code: String {
+        case invalidURL
+        case urlConstructionFailed
+        case requestBodyEncodingFailed
+        case networkFailure
+        case webRTCFailure
+        case customError
+        case existingCallInProgress
+        case noCallInProgress
+        case decodingError
+        case invalidJsonData
+    }
+
+    public var code: Code {
+        switch self {
+        case .invalidURL:
+            return .invalidURL
+        case .urlConstructionFailed:
+            return .urlConstructionFailed
+        case .requestBodyEncodingFailed:
+            return .requestBodyEncodingFailed
+        case .networkFailure:
+            return .networkFailure
+        case .webRTCFailure:
+            return .webRTCFailure
+        case .customError:
+            return .customError
+        case .existingCallInProgress:
+            return .existingCallInProgress
+        case .noCallInProgress:
+            return .noCallInProgress
+        case .decodingError,
+             .decodingFailure:
+            return .decodingError
+        case .invalidJsonData:
+            return .invalidJsonData
+        }
+    }
+
+    public var underlyingError: Error? {
+        switch self {
+        case .requestBodyEncodingFailed(let underlying):
+            return underlying
+        case .networkFailure(let underlying):
+            return underlying
+        case .webRTCFailure(_, let underlying):
+            return underlying
+        case .decodingFailure(_, _, let underlying):
+            return underlying
+        case .invalidURL,
+             .urlConstructionFailed,
+             .customError,
+             .existingCallInProgress,
+             .noCallInProgress:
+            return nil
+        case .decodingError,
+             .invalidJsonData:
+            return nil
+        }
+    }
+}
+
+extension VapiError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL."
+        case .urlConstructionFailed(let host, let path):
+            return "Failed to construct URL for host '\(host)' and path '\(path)'."
+        case .requestBodyEncodingFailed:
+            return "Failed to encode request body."
+        case .networkFailure:
+            return "Network request failed."
+        case .webRTCFailure(let operation, _):
+            return "WebRTC operation failed: \(operation)."
+        case .customError(let message):
+            return message
+        case .existingCallInProgress:
+            return "A call is already in progress."
+        case .noCallInProgress:
+            return "No call is currently in progress."
+        case .decodingError(let message, _):
+            return "Decoding error: \(message)"
+        case .decodingFailure(let message, _, _):
+            return "Decoding error: \(message)"
+        case .invalidJsonData:
+            return "Invalid JSON data."
+        }
+    }
 }

--- a/Sources/NetworkManager.swift
+++ b/Sources/NetworkManager.swift
@@ -9,13 +9,23 @@ class NetworkManager {
     private let session = URLSession(configuration: .default)
     
     func perform<T: Decodable>(request: URLRequest) async throws -> T {
-        let (data, _) = try await session.data(for: request)
+        let data: Data
+        do {
+            (data, _) = try await session.data(for: request)
+        } catch {
+            throw VapiError.networkFailure(underlying: error)
+        }
+
         do {
             let result = try JSONDecoder().decode(T.self, from: data)
             return result
         } catch {
             let responseString = String(data: data, encoding: .utf8)
-            throw VapiError.decodingError(message: error.localizedDescription, response: responseString)
+            throw VapiError.decodingFailure(
+                message: error.localizedDescription,
+                response: responseString,
+                underlying: error
+            )
         }
     }
 }

--- a/Sources/Vapi.swift
+++ b/Sources/Vapi.swift
@@ -65,12 +65,23 @@ public final class Vapi: CallClientDelegate {
         case hang
         case error(Swift.Error)
     }
+
+    /// Structured telemetry emitted whenever the SDK encounters an error.
+    public struct TelemetryEvent {
+        public let timestamp: Date
+        public let operation: String
+        public let errorCode: String
+        public let message: String
+        public let metadata: [String: String]
+        public let underlyingError: String?
+    }
     
     // MARK: - Properties
 
     public let configuration: Configuration
 
     fileprivate let eventSubject = PassthroughSubject<Event, Never>()
+    public var telemetryHandler: ((TelemetryEvent) -> Void)?
     
     private let networkManager = NetworkManager()
     private var call: CallClient?
@@ -153,28 +164,36 @@ public final class Vapi: CallClientDelegate {
                 try await call?.leave()
                 call = nil
             } catch {
-                self.callDidFail(with: error)
+                let wrappedError = self.wrapAsWebRTCFailure(error, operation: "stop.leave")
+                self.callDidFail(with: wrappedError)
             }
         }
     }
 
     public func send(message: VapiMessage) async throws {
+        let jsonData: Data
+
         do {
-          // Use JSONEncoder to convert the message to JSON Data
-          let jsonData = try JSONEncoder().encode(message)
-          
-          // Debugging: Print the JSON data to verify its format (optional)
-          if let jsonString = String(data: jsonData, encoding: .utf8) {
-              print(jsonString)
-          }
-          
-          // Send the JSON data to all targets
-          try await self.call?.sendAppMessage(json: jsonData, to: .all)
-      } catch {
-          // Handle encoding error
-          print("Error encoding message to JSON: \(error)")
-          throw error // Re-throw the error to be handled by the caller
-      }
+            jsonData = try JSONEncoder().encode(message)
+        } catch {
+            let wrappedError = wrapAsRequestBodyEncodingFailure(error)
+            emitTelemetry(operation: "send.encodeMessage", error: wrappedError)
+            throw wrappedError
+        }
+
+        // Debugging: Print the JSON data to verify its format (optional)
+        if let jsonString = String(data: jsonData, encoding: .utf8) {
+            print(jsonString)
+        }
+
+        do {
+            // Send the JSON data to all targets
+            try await self.call?.sendAppMessage(json: jsonData, to: .all)
+        } catch {
+            let wrappedError = wrapAsWebRTCFailure(error, operation: "send.appMessage")
+            emitTelemetry(operation: "send.appMessage", error: wrappedError)
+            throw wrappedError
+        }
     }
 
     public func setMuted(_ muted: Bool) async throws {
@@ -191,8 +210,10 @@ public final class Vapi: CallClientDelegate {
                 print("Audio unmuted")
             }
         } catch {
-            print("Failed to set mute state: \(error)")
-            throw error
+            let wrappedError = wrapAsWebRTCFailure(error, operation: "setMuted")
+            print("Failed to set mute state: \(wrappedError)")
+            emitTelemetry(operation: "setMuted", error: wrappedError, metadata: ["muted": String(muted)])
+            throw wrappedError
         }
     }
 
@@ -212,8 +233,10 @@ public final class Vapi: CallClientDelegate {
                 print("Audio unmuted")
             }
         } catch {
-            print("Failed to toggle mute state: \(error)")
-            throw error
+            let wrappedError = wrapAsWebRTCFailure(error, operation: "isMuted.toggle")
+            print("Failed to toggle mute state: \(wrappedError)")
+            emitTelemetry(operation: "isMuted.toggle", error: wrappedError)
+            throw wrappedError
         }
     }
     
@@ -245,8 +268,10 @@ public final class Vapi: CallClientDelegate {
             )
             isAssistantMuted = muted
         } catch {
+            let wrappedError = wrapAsWebRTCFailure(error, operation: "setAssistantMuted")
             print("Failed to set subscription state to \(muted ? "Staged" : "Subscribed") for remote assistant")
-            throw error
+            emitTelemetry(operation: "setAssistantMuted", error: wrappedError, metadata: ["muted": String(muted)])
+            throw wrappedError
         }
     }
     
@@ -265,8 +290,14 @@ public final class Vapi: CallClientDelegate {
         do {
             try await call.setPreferredAudioDevice(audioDeviceType)
         } catch {
-            print("Failed to change the AudioDeviceType with error: \(error)")
-            throw error
+            let wrappedError = wrapAsWebRTCFailure(error, operation: "setAudioDeviceType")
+            print("Failed to change the AudioDeviceType with error: \(wrappedError)")
+            emitTelemetry(
+                operation: "setAudioDeviceType",
+                error: wrappedError,
+                metadata: ["audioDeviceType": String(describing: audioDeviceType)]
+            )
+            throw wrappedError
         }
     }
 
@@ -301,7 +332,8 @@ public final class Vapi: CallClientDelegate {
                     )
                 )
             } catch {
-                callDidFail(with: error)
+                let wrappedError = wrapAsWebRTCFailure(error, operation: "joinCall.joinOrStartRecording")
+                callDidFail(with: wrappedError)
             }
         }
     }
@@ -327,11 +359,76 @@ public final class Vapi: CallClientDelegate {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         return request
     }
+
+    private func wrapAsNetworkFailure(_ error: Error) -> VapiError {
+        if let vapiError = error as? VapiError {
+            return vapiError
+        }
+
+        return .networkFailure(underlying: error)
+    }
+
+    private func wrapAsWebRTCFailure(_ error: Error, operation: String) -> VapiError {
+        if let vapiError = error as? VapiError {
+            return vapiError
+        }
+
+        return .webRTCFailure(operation: operation, underlying: error)
+    }
+
+    private func wrapAsRequestBodyEncodingFailure(_ error: Error) -> VapiError {
+        if let vapiError = error as? VapiError {
+            return vapiError
+        }
+
+        return .requestBodyEncodingFailed(underlying: error)
+    }
+
+    private func emitTelemetry(operation: String, error: Error, metadata: [String: String] = [:]) {
+        let vapiError = error as? VapiError
+        let wrappedMessage = vapiError?.errorDescription
+        let errorCode = vapiError?.code.rawValue ?? "unknown"
+        let nsError = error as NSError
+        let underlying = vapiError?.underlyingError ?? (nsError.userInfo[NSUnderlyingErrorKey] as? Error)
+        let underlyingDescription = underlying.map { String(describing: $0) }
+        let message = wrappedMessage ?? error.localizedDescription
+
+        let telemetryEvent = TelemetryEvent(
+            timestamp: Date(),
+            operation: operation,
+            errorCode: errorCode,
+            message: message,
+            metadata: metadata,
+            underlyingError: underlyingDescription
+        )
+        telemetryHandler?(telemetryEvent)
+
+        var payload: [String: Any] = [
+            "timestamp": ISO8601DateFormatter().string(from: telemetryEvent.timestamp),
+            "operation": telemetryEvent.operation,
+            "errorCode": telemetryEvent.errorCode,
+            "message": telemetryEvent.message,
+            "metadata": telemetryEvent.metadata,
+        ]
+        if let underlyingDescription {
+            payload["underlyingError"] = underlyingDescription
+        }
+
+        if
+            let jsonData = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
+            let jsonString = String(data: jsonData, encoding: .utf8)
+        {
+            print("VapiTelemetry \(jsonString)")
+        } else {
+            print("VapiTelemetry operation=\(operation) errorCode=\(errorCode) message=\(message)")
+        }
+    }
     
     private func startCall(body: [String: Any]) async throws -> WebCallResponse {
         guard let url = makeURL(for: "/call/web") else {
-            callDidFail(with: VapiError.invalidURL)
-            throw VapiError.customError("Unable to create web call")
+            let wrappedError = VapiError.urlConstructionFailed(host: configuration.host, path: "/call/web")
+            callDidFail(with: wrappedError)
+            throw wrappedError
         }
         
         var request = makeURLRequest(for: url)
@@ -339,8 +436,9 @@ public final class Vapi: CallClientDelegate {
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
         } catch {
-            self.callDidFail(with: error)
-            throw VapiError.customError(error.localizedDescription)
+            let wrappedError = wrapAsRequestBodyEncodingFailure(error)
+            self.callDidFail(with: wrappedError)
+            throw wrappedError
         }
         
         do {
@@ -349,8 +447,9 @@ public final class Vapi: CallClientDelegate {
             joinCall(url: response.webCallUrl, recordVideo: isVideoRecordingEnabled)
             return response
         } catch {
-            callDidFail(with: error)
-            throw VapiError.customError(error.localizedDescription)
+            let wrappedError = wrapAsNetworkFailure(error)
+            callDidFail(with: wrappedError)
+            throw wrappedError
         }
     }
     
@@ -387,7 +486,9 @@ public final class Vapi: CallClientDelegate {
         do {
             try await call?.startLocalAudioLevelObserver()
         } catch {
-            throw error
+            let wrappedError = wrapAsWebRTCFailure(error, operation: "startLocalAudioLevelObserver")
+            emitTelemetry(operation: "startLocalAudioLevelObserver", error: wrappedError)
+            throw wrappedError
         }
     }
     
@@ -395,7 +496,9 @@ public final class Vapi: CallClientDelegate {
         do {
             try await call?.startRemoteParticipantsAudioLevelObserver()
         } catch {
-            throw error
+            let wrappedError = wrapAsWebRTCFailure(error, operation: "startRemoteParticipantsAudioLevelObserver")
+            emitTelemetry(operation: "startRemoteParticipantsAudioLevelObserver", error: wrappedError)
+            throw wrappedError
         }
     }
     
@@ -414,6 +517,7 @@ public final class Vapi: CallClientDelegate {
     }
     
     func callDidFail(with error: Swift.Error) {
+        emitTelemetry(operation: "callDidFail", error: error)
         print("Got error while joining/leaving call: \(error).")
         
         self.eventSubject.send(.error(error))
@@ -434,10 +538,17 @@ public final class Vapi: CallClientDelegate {
             let jsonData = try JSONSerialization.data(withJSONObject: message, options: [])
             
             Task {
-                try await call?.sendAppMessage(json: jsonData, to: .all)
+                do {
+                    try await call?.sendAppMessage(json: jsonData, to: .all)
+                } catch {
+                    let wrappedError = self.wrapAsWebRTCFailure(error, operation: "participantUpdated.sendAppMessage")
+                    self.emitTelemetry(operation: "participantUpdated.sendAppMessage", error: wrappedError)
+                }
             }
         } catch {
-            print("Error sending message: \(error.localizedDescription)")
+            let wrappedError = wrapAsRequestBodyEncodingFailure(error)
+            emitTelemetry(operation: "participantUpdated.encodePlayableMessage", error: wrappedError)
+            print("Error sending message: \(wrappedError.localizedDescription)")
         }
     }
     
@@ -561,6 +672,11 @@ public final class Vapi: CallClientDelegate {
         } catch {
             let messageText = String(data: jsonData, encoding: .utf8)
             print("Error parsing app message \"\(messageText ?? "")\": \(error.localizedDescription)")
+            emitTelemetry(
+                operation: "appMessage.decode",
+                error: error,
+                metadata: ["rawMessage": messageText ?? ""]
+            )
         }
     }
 }

--- a/Tests/VapiTests.swift
+++ b/Tests/VapiTests.swift
@@ -2,5 +2,25 @@ import XCTest
 @testable import Vapi
 
 final class VapiTests: XCTestCase {
-    func testExample() throws {}
+    func testErrorCodesForNewFailureTypes() throws {
+        let networkError = VapiError.networkFailure(underlying: URLError(.timedOut))
+        XCTAssertEqual(networkError.code, .networkFailure)
+
+        let webRTCError = VapiError.webRTCFailure(operation: "joinCall.joinOrStartRecording", underlying: URLError(.cannotConnectToHost))
+        XCTAssertEqual(webRTCError.code, .webRTCFailure)
+
+        let urlError = VapiError.urlConstructionFailed(host: "bad host", path: "/call/web")
+        XCTAssertEqual(urlError.code, .urlConstructionFailed)
+    }
+
+    func testUnderlyingErrorIsPreserved() throws {
+        let underlying = URLError(.timedOut)
+        let error = VapiError.networkFailure(underlying: underlying)
+
+        guard let resolvedUnderlying = error.underlyingError as? URLError else {
+            return XCTFail("Expected URLError as underlying error")
+        }
+
+        XCTAssertEqual(resolvedUnderlying.code, underlying.code)
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Improve iOS SDK error handling by introducing distinct error types, preserving underlying errors, and adding structured telemetry.

The previous implementation flattened all errors into `VapiError.customError(error.localizedDescription)`, making it impossible for consumers to programmatically differentiate between URL construction, network, and WebRTC failures. This PR addresses that by providing specific error cases and retaining the original error chain.

---
<p><a href="https://cursor.com/agents/bc-b6b42a29-2023-48e7-b0c0-ab69bf808d60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6b42a29-2023-48e7-b0c0-ab69bf808d60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->