### PR TITLE
Vapi error message truncation

### DIFF
--- a/Sources/Models/VapiError.swift
+++ b/Sources/Models/VapiError.swift
@@ -7,11 +7,31 @@
 
 import Foundation
 
-public enum VapiError: Swift.Error {
+public enum VapiError: Swift.Error, LocalizedError {
     case invalidURL
     case customError(String)
     case existingCallInProgress
     case noCallInProgress
     case decodingError(message: String, response: String? = nil)
     case invalidJsonData
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "The URL provided is invalid."
+        case .customError(let message):
+            return message
+        case .existingCallInProgress:
+            return "A call is already in progress."
+        case .noCallInProgress:
+            return "No call is currently in progress."
+        case .decodingError(let message, let response):
+            if let response {
+                return "Decoding error: \(message) — Response: \(response)"
+            }
+            return "Decoding error: \(message)"
+        case .invalidJsonData:
+            return "The JSON data is invalid."
+        }
+    }
 }

--- a/Sources/Models/VapiError.swift
+++ b/Sources/Models/VapiError.swift
@@ -18,20 +18,17 @@ public enum VapiError: Swift.Error, LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .invalidURL:
-            return "The URL provided is invalid."
+            return "invalidURL"
         case .customError(let message):
             return message
         case .existingCallInProgress:
-            return "A call is already in progress."
+            return "existingCallInProgress"
         case .noCallInProgress:
-            return "No call is currently in progress."
+            return "noCallInProgress"
         case .decodingError(let message, let response):
-            if let response {
-                return "Decoding error: \(message) — Response: \(response)"
-            }
-            return "Decoding error: \(message)"
+            return response ?? message
         case .invalidJsonData:
-            return "The JSON data is invalid."
+            return "invalidJsonData"
         }
     }
 }

--- a/Sources/Models/VapiError.swift
+++ b/Sources/Models/VapiError.swift
@@ -17,18 +17,12 @@ public enum VapiError: Swift.Error, LocalizedError {
 
     public var errorDescription: String? {
         switch self {
-        case .invalidURL:
-            return "invalidURL"
         case .customError(let message):
             return message
-        case .existingCallInProgress:
-            return "existingCallInProgress"
-        case .noCallInProgress:
-            return "noCallInProgress"
         case .decodingError(let message, let response):
             return response ?? message
-        case .invalidJsonData:
-            return "invalidJsonData"
+        default:
+            return String(describing: self)
         }
     }
 }

--- a/Sources/NetworkManager.swift
+++ b/Sources/NetworkManager.swift
@@ -15,7 +15,30 @@ class NetworkManager {
             return result
         } catch {
             let responseString = String(data: data, encoding: .utf8)
-            throw VapiError.decodingError(message: error.localizedDescription, response: responseString)
+            throw VapiError.decodingError(message: Self.detailedErrorMessage(from: error), response: responseString)
+        }
+    }
+
+    static func detailedErrorMessage(from error: Error) -> String {
+        guard let decodingError = error as? DecodingError else {
+            return String(describing: error)
+        }
+
+        switch decodingError {
+        case .typeMismatch(let type, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            return "Type mismatch for \(type) at path '\(path)': \(context.debugDescription)"
+        case .valueNotFound(let type, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            return "Value not found for \(type) at path '\(path)': \(context.debugDescription)"
+        case .keyNotFound(let key, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            return "Key '\(key.stringValue)' not found at path '\(path)': \(context.debugDescription)"
+        case .dataCorrupted(let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            return "Data corrupted at path '\(path)': \(context.debugDescription)"
+        @unknown default:
+            return String(describing: error)
         }
     }
 }

--- a/Sources/NetworkManager.swift
+++ b/Sources/NetworkManager.swift
@@ -15,30 +15,7 @@ class NetworkManager {
             return result
         } catch {
             let responseString = String(data: data, encoding: .utf8)
-            throw VapiError.decodingError(message: Self.detailedErrorMessage(from: error), response: responseString)
-        }
-    }
-
-    static func detailedErrorMessage(from error: Error) -> String {
-        guard let decodingError = error as? DecodingError else {
-            return String(describing: error)
-        }
-
-        switch decodingError {
-        case .typeMismatch(let type, let context):
-            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
-            return "Type mismatch for \(type) at path '\(path)': \(context.debugDescription)"
-        case .valueNotFound(let type, let context):
-            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
-            return "Value not found for \(type) at path '\(path)': \(context.debugDescription)"
-        case .keyNotFound(let key, let context):
-            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
-            return "Key '\(key.stringValue)' not found at path '\(path)': \(context.debugDescription)"
-        case .dataCorrupted(let context):
-            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
-            return "Data corrupted at path '\(path)': \(context.debugDescription)"
-        @unknown default:
-            return String(describing: error)
+            throw VapiError.decodingError(message: String(describing: error), response: responseString)
         }
     }
 }

--- a/Sources/Vapi.swift
+++ b/Sources/Vapi.swift
@@ -340,7 +340,7 @@ public final class Vapi: CallClientDelegate {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
         } catch {
             self.callDidFail(with: error)
-            throw VapiError.customError(error.localizedDescription)
+            throw VapiError.customError(String(describing: error))
         }
         
         do {
@@ -348,9 +348,12 @@ public final class Vapi: CallClientDelegate {
             let isVideoRecordingEnabled = response.artifactPlan?.videoRecordingEnabled ?? false
             joinCall(url: response.webCallUrl, recordVideo: isVideoRecordingEnabled)
             return response
+        } catch let vapiError as VapiError {
+            callDidFail(with: vapiError)
+            throw vapiError
         } catch {
             callDidFail(with: error)
-            throw VapiError.customError(error.localizedDescription)
+            throw VapiError.customError(String(describing: error))
         }
     }
     
@@ -560,7 +563,7 @@ public final class Vapi: CallClientDelegate {
             eventSubject.send(event)
         } catch {
             let messageText = String(data: jsonData, encoding: .utf8)
-            print("Error parsing app message \"\(messageText ?? "")\": \(error.localizedDescription)")
+            print("Error parsing app message \"\(messageText ?? "")\": \(error)")
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Improve error reporting by making `VapiError` conform to `LocalizedError` and preserving detailed error information in `NetworkManager` and `Vapi.swift`.

The previous implementation resulted in generic error messages (e.g., "Vapi.VapiError error 1" or "The data couldn't be read...") because `VapiError` lacked `LocalizedError` conformance and `error.localizedDescription` was used, which stripped away crucial debugging details from `DecodingError` and other wrapped errors. This PR ensures full error context is retained and displayed.

<div><a href="https://cursor.com/agents/bc-d5ae68a5-2e14-47dd-90ee-28e0f64fff8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5ae68a5-2e14-47dd-90ee-28e0f64fff8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->